### PR TITLE
RSDEV-444: Upgrade rspace-evernote-parser to 2.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## 2.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## 1.1.3
 - switch to parent-pom 2.1.2 (upgrades various dependencies)
 - move away from apache commons-lang dependency (use commons-lang3 instead)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>3.0.0</version>
+		<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
 	</parent>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
 	<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
-		<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-evernote-parser</artifactId>
-	<version>1.1.3</version>
+	<version>2.0.0</version>
 
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>2.1.2</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<repositories>
@@ -73,8 +73,9 @@
 			<scope>test</scope>
 		</dependency>
 	<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+		<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/src/main/java/com/researchspace/evernote/EnExport.java
+++ b/src/main/java/com/researchspace/evernote/EnExport.java
@@ -9,13 +9,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.activation.MimeType;
-import javax.activation.MimeTypeParseException;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.activation.MimeType;
+import jakarta.activation.MimeTypeParseException;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;

--- a/src/main/java/com/researchspace/evernote/EvernoteParser.java
+++ b/src/main/java/com/researchspace/evernote/EvernoteParser.java
@@ -2,9 +2,9 @@ package com.researchspace.evernote;
 
 import java.io.*;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;

--- a/src/main/java/com/researchspace/evernote/NodeAttributes.java
+++ b/src/main/java/com/researchspace/evernote/NodeAttributes.java
@@ -2,9 +2,9 @@ package com.researchspace.evernote;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import lombok.Data;
 

--- a/src/main/java/com/researchspace/evernote/Note.java
+++ b/src/main/java/com/researchspace/evernote/Note.java
@@ -3,9 +3,9 @@ package com.researchspace.evernote;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import lombok.Data;
 

--- a/src/main/java/com/researchspace/evernote/Resource.java
+++ b/src/main/java/com/researchspace/evernote/Resource.java
@@ -2,10 +2,10 @@ package com.researchspace.evernote;
 
 import java.util.Optional;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/com/researchspace/evernote/ResourceAttributes.java
+++ b/src/main/java/com/researchspace/evernote/ResourceAttributes.java
@@ -2,9 +2,9 @@ package com.researchspace.evernote;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import lombok.Data;
 @Data


### PR DESCRIPTION
Upgrade rspace-evernote-parser to 2.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Migrates JAXB imports from `javax.xml.bind` to `jakarta.xml.bind` across all model classes and inherits the API version from the parent BOM.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>